### PR TITLE
convert branch to full sha1

### DIFF
--- a/.circleci/circle_trigger.sh
+++ b/.circleci/circle_trigger.sh
@@ -48,7 +48,7 @@ fi
 
 if [[ ${LAST_COMPLETED_BUILD_SHA} == "null" ]]; then
   echo -e "\e[93mNo CI builds for branch ${PARENT_BRANCH}. Using master.\e[0m"
-  LAST_COMPLETED_BUILD_SHA=master
+  LAST_COMPLETED_BUILD_SHA=$(git rev-parse origin/master)
 fi
 
 ############################################


### PR DESCRIPTION
Addresses a CircleCI issue.
only git sha1 are allowed in git revision ranges

Fixes #9